### PR TITLE
Add date approximation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ In case you wish to use the question data in a different way (eg, you retreived 
   "answer": string,
   "season": string,
   "timestamp": string,
+  "timestamp_ms": number
   "answered": boolean,
   "tags": string[]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
                 "@mikro-orm/reflection": "^5.1.3",
                 "@mikro-orm/sqlite": "^5.1.3",
                 "cheerio": "^1.0.0-rc.3",
+                "ms": "^2.1.3",
                 "node-fetch": "^2.6.7",
                 "winston": "^3.4.0"
             },
             "devDependencies": {
                 "@types/cheerio": "^0.22.22",
+                "@types/ms": "^0.7.31",
                 "@types/node-fetch": "^2.5.7",
                 "@types/winston": "^2.4.4",
                 "@typescript-eslint/eslint-plugin": "^5.10.1",
@@ -444,6 +446,12 @@
             "version": "7.0.11",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "dev": true
+        },
+        "node_modules/@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -1134,6 +1142,11 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/debug/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -2404,9 +2417,9 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -3830,6 +3843,12 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "17.0.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
@@ -4327,6 +4346,13 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                }
             }
         },
         "deep-is": {
@@ -5284,9 +5310,9 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "natural-compare": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@mikro-orm/reflection": "^5.1.3",
         "@mikro-orm/sqlite": "^5.1.3",
         "cheerio": "^1.0.0-rc.3",
+        "ms": "^2.1.3",
         "node-fetch": "^2.6.7",
         "winston": "^3.4.0"
     },
@@ -33,6 +34,7 @@
     },
     "devDependencies": {
         "@types/cheerio": "^0.22.22",
+        "@types/ms": "^0.7.31",
         "@types/node-fetch": "^2.5.7",
         "@types/winston": "^2.4.4",
         "@typescript-eslint/eslint-plugin": "^5.10.1",

--- a/src/entities/Question.ts
+++ b/src/entities/Question.ts
@@ -31,6 +31,9 @@ export class Question implements QuestionData {
     timestamp!: string
 
     @Property()
+    timestamp_ms!: number
+
+    @Property()
     answered!: boolean
 
     @Property()

--- a/src/modules/scraper.ts
+++ b/src/modules/scraper.ts
@@ -1,3 +1,4 @@
+import { ago, AgoString } from './../util/date';
 import cheerioModule from "cheerio"
 import fetch from "node-fetch"
 import {
@@ -22,6 +23,7 @@ export interface QuestionData {
     answer: string
     season: string
     timestamp: string
+    timestamp_ms: number
     answered: boolean
     tags: string[]
 }
@@ -73,6 +75,7 @@ export const fetchQuestion = async (url: string, silent = true): Promise<Questio
     const answer = unleak(unformat($('div.answer.approved .content-body').text()))
     const season = match.groups.season
     const timestamp = unleak(unformat($('div.timestamp').text()))
+    const timestamp_ms = ago(timestamp as AgoString).getTime();
     const answered = Boolean(answer)
     const tags = $('div.tags a')
         .map((i, el) => unleak($(el).text().trim())).get()
@@ -80,7 +83,8 @@ export const fetchQuestion = async (url: string, silent = true): Promise<Questio
     return {
         id, url, author, category,
         title, question, answer,
-        season, timestamp, answered, tags
+        season, timestamp, timestamp_ms,
+        answered, tags
     }
 }
 

--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -1,0 +1,100 @@
+import ms from "ms";
+
+const units = [
+    "minute",
+    "hour",
+    "day",
+    "week",
+    "month",
+    "year"
+] as const;
+
+export type DateUnits = typeof units[number];
+
+export type AgoString = `${number} ${DateUnits} ago`;
+
+export type FloorOptions = {
+    constrainToMonth: boolean
+}
+
+const minutefloor = (date: Date) => {
+    const copy = new Date(date);
+    copy.setSeconds(0);
+    copy.setMilliseconds(0);
+    return copy;
+}
+
+const hourfloor = (date: Date) => {
+    const copy = new Date(date);
+    copy.setMinutes(0);
+    return minutefloor(copy);
+}
+
+const dayfloor = (date: Date) => {
+    const copy = new Date(date);
+    copy.setHours(0);
+    return hourfloor(copy);
+}
+
+const weekfloor = (date: Date, opt: FloorOptions = { constrainToMonth: false }) => {
+    const copy = new Date(date);
+    if (!opt.constrainToMonth) {
+        const offset = 0 - copy.getDay();
+        copy.setDate(copy.getDate() + offset);
+    }
+    return dayfloor(copy);
+}
+
+const monthfloor = (date: Date) => {
+    const copy = new Date(date);
+    copy.setDate(1);
+    return weekfloor(copy, { constrainToMonth: true });
+}
+
+const yearfloor = (date: Date) => {
+    const copy = new Date(date);
+    copy.setMonth(0);
+    return monthfloor(copy);
+}
+
+const floordate = (unit: DateUnits, date: Date) => ({
+    "minute": minutefloor(date),
+    "hour": hourfloor(date),
+    "day": dayfloor(date),
+    "week": weekfloor(date),
+    "month": monthfloor(date),
+    "year": yearfloor(date)
+})[unit];
+
+export const yyyymmdd = (date: Date) => {
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const monthPadding = month < 10 ? "0" : "";
+    const day = date.getDate();
+    const dayPadding = day < 10 ? "0" : "";
+    return `${year}-${monthPadding}${month}-${dayPadding}${day}`;
+}
+
+export const ago = (input: AgoString) => {
+    const regex = new RegExp(`(?<val>\\d+) (?<unit>${units.join("|")})s? ago`);
+    const match = input.match(regex);
+    if (!match) {
+        throw Error(`"${input}" must match the format [value] [unit] ago (eg, 1 month ago)`);
+    }
+
+    const value = parseInt(match.groups!.val);
+    const unit = match.groups!.unit as DateUnits;
+
+    let createdDate;
+    const now = new Date(Date.now());
+
+    if (unit === "month") {
+        now.setMonth(now.getMonth() - value);
+        createdDate = floordate("month", now);
+    } else {
+        const offset = ms(`${value} ${unit}`);
+        const elapsed = now.getTime() - offset;
+        createdDate = floordate(unit, new Date(elapsed));
+    }
+    return createdDate;
+}


### PR DESCRIPTION
Add the ability to approximate the creation date of Q&As. RobotEvents does not give the exact timestamp for questions, only a description indicating how long ago it was asked (eg, "1 month ago"). However, it would be nice to approximate the timeframe in which a question was asked. This PR adds that feature.

Notes 
- The approximation is "floored" to the beginning of the time unit given. Example: "1 month ago" relative to the date of this PR (5/25/2022) would go to 4/25/2022, and since the unit is in months, the final approximation would be 4/1/2022. This is because RobotEvents doesn't give fractional time units. In order to maximize the potential timeframe the question could have been asked within, we just assume at the very least, it had to have been asked at the beginning of whatever unit of time was used.